### PR TITLE
Removes step in README.md not required anymore

### DIFF
--- a/full-stack/README.md
+++ b/full-stack/README.md
@@ -8,7 +8,6 @@ boots the exemplary consumer application and resource server.
 Run this example with:
 
 ```
-$ make pull
 $ make start-full-stack
 ```
 

--- a/hydra-bc/README.md
+++ b/hydra-bc/README.md
@@ -11,7 +11,6 @@ You should use this example only if you are upgrading from ORY Hydra < 1.0.0 and
 Run this example with:
 
 ```
-$ make pull
 $ make start-hydra-bc
 ```
 

--- a/hydra/README.md
+++ b/hydra/README.md
@@ -5,7 +5,6 @@ It works very similar to the other examples as it provides a custom Dockerfile a
 the ORY Hydra clients.
 
 ```
-$ make pull
 $ make start-hydra
 ```
 


### PR DESCRIPTION
Makefile doesn't include "make pull" anymore.

Signed-off-by: Oscar Trullols <oscartrullols@gmail.com>